### PR TITLE
Add support for RISC-V

### DIFF
--- a/src/parted/__init__.py
+++ b/src/parted/__init__.py
@@ -325,7 +325,9 @@ archLabels = {'i386': ['msdos', 'gpt'],
               'ppc64le': ['msdos', 'gpt'],
               'x86_64': ['msdos', 'gpt'],
               'aarch64': ['msdos', 'gpt'],
-              'armv7l': ['msdos', 'gpt']}
+              'armv7l': ['msdos', 'gpt'],
+              'riscv32': ['msdos', 'gpt'],
+              'riscv64': ['msdos', 'gpt']}
 
 # Adapted from:
 # http://stackoverflow.com/questions/922550/how-to-mark-a-global-as-deprecated-in-python
@@ -362,9 +364,9 @@ def Deprecated(mod, deprecated=None):
 __archLabels = (('amiga', 'ppc(64)?$'),
                 ('bsd', 'alpha$'),
                 ('dasd', 's390x?$'),
-                ('gpt', 'i[3-6]86$|x86_64$|ia64$|ppc(64|64le)?$|aarch64$|armv7l$'),
+                ('gpt', 'i[3-6]86$|x86_64$|ia64$|ppc(64|64le)?$|aarch64$|armv7l$|riscv(32|64)$'),
                 ('mac', 'ppc(64)?$'),
-                ('msdos', 'i[3-6]86$|x86_64$|s390x?$|alpha$|ia64$|ppc(64|64le)?$|aarch64$|armv7l$'),
+                ('msdos', 'i[3-6]86$|x86_64$|s390x?$|alpha$|ia64$|ppc(64|64le)?$|aarch64$|armv7l$|riscv(32|64)$'),
                 ('sun', 'sparc(64)?$'))
 
 def getLabels(arch=None):

--- a/tests/test_parted_parted.py
+++ b/tests/test_parted_parted.py
@@ -63,6 +63,8 @@ class GetLabelsTestCase(unittest.TestCase):
         self.assertSetEqual(parted.getLabels('ia64'), {'gpt', 'msdos'})
         self.assertSetEqual(parted.getLabels('aarch64'), {'gpt', 'msdos'})
         self.assertSetEqual(parted.getLabels('armv7l'), {'gpt', 'msdos'})
+        self.assertSetEqual(parted.getLabels('riscv32'), {'gpt', 'msdos'})
+        self.assertSetEqual(parted.getLabels('riscv64'), {'gpt', 'msdos'})
 
 class GetDeviceTestCase(RequiresDeviceNode):
     def runTest(self):


### PR DESCRIPTION
RISC-V is using the usual partition labels.