### PR TITLE
Add initial Github Actions CI support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,36 @@
+name: Test
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  unit-tests:
+    runs-on: ubuntu-latest
+    container:
+      image: registry.fedoraproject.org/fedora:34
+    steps:
+      - uses: actions/checkout@v2
+      - name: container running
+        run: |
+          # Install required RPMS
+          dnf install -y \
+              bash \
+              e2fsprogs \
+              findutils \
+              gcc \
+              make \
+              parted \
+              parted-devel \
+              pkg-config \
+              python3 \
+              python3-devel \
+              python3-pip \
+              udev
+          pip install --upgrade pip
+          pip install --upgrade coverage pytest setuptools six
+          env PYTHON=python3 make test coverage COVERAGE=coverage

--- a/tests/test__ped_ped.py
+++ b/tests/test__ped_ped.py
@@ -200,6 +200,7 @@ class DeviceGetTestCase(RequiresDevice):
         self.assertRaises(_ped.DeviceException, _ped.device_get, None)
 
 @unittest.skipUnless(os.geteuid() == 0, 'Requires root')
+@unittest.skipUnless("container" not in os.environ, 'Running in a container')
 class DeviceGetNextTestCase(unittest.TestCase, BuildList):
     def runTest(self):
         # Make sure there are some devices in the system first and then


### PR DESCRIPTION
On pull requests and push to master run the test-suite in Github
Actions using a Fedora 34 container image.