### PR TITLE
setup.py: port to setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,12 +25,7 @@ import glob
 import os
 import platform
 import sys
-from distutils.ccompiler import new_compiler
-from distutils.errors import CompileError
-from distutils.errors import LinkError
-from distutils.core import setup
-from distutils.core import Extension
-from distutils.version import LooseVersion
+from setuptools import setup, Extension
 
 pyparted_version = '3.11.7'
 python_version = sys.version_info
@@ -45,19 +40,13 @@ if python_version < need_python_version:
 # http://code.activestate.com/recipes/502261-python-distutils-pkg-config/
 def pkgconfig(*packages, **kwargs):
     flag_map = {'-I': 'include_dirs', '-L': 'library_dirs', '-l': 'libraries'}
-    for token in subprocess.check_output(["pkg-config", "--libs", "--cflags"] + list(packages)).decode('utf-8').split():
-
-        kwargs.setdefault(flag_map.get(token[:2]), []).append(token[2:])
-    return kwargs
-
-def check_mod_version(module, version):
-    modversion = subprocess.check_output(["pkg-config", "--modversion", module]).decode('utf-8').split()[0]
-    if not LooseVersion(modversion) >= LooseVersion(version):
-        sys.stderr.write("*** Minimum required %s version: %s, found: %s\n" % (module, version, modversion,))
-        sys.exit(1)
-    return
-
-check_mod_version('libparted', need_libparted_version)
+    try:
+        for token in subprocess.check_output(["pkg-config", "--libs", "--cflags"] + list(packages),
+                                            universal_newlines=True).split():
+            kwargs.setdefault(flag_map.get(token[:2]), []).append(token[2:])
+        return kwargs
+    except subprocess.CalledProcessError as e:
+        sys.exit("Cannot find pkg-config dependencies:\n" + e.output)
 
 # This list is in the format necessary for the define_macros parameter
 # for an Extension() module definition.  See:
@@ -77,6 +66,6 @@ setup(name='pyparted',
       ext_modules=[Extension('_ped',
                              sorted(glob.glob(os.path.join('src', '*.c'))),
                              define_macros=features,
-                             **pkgconfig('libparted',
+                             **pkgconfig('libparted >= %s' % need_libparted_version,
                                          include_dirs=['include']))
                   ])


### PR DESCRIPTION
Python 3.10 has deprecated distutils[1], and it will be removed entirely
in Python 3.12.

As the setuptools API is identical, moving to setuptools is trivial by
changing the import.

Remove check_mod_version, a version specifier can be passed directly
to pkg-config.

Remove unused imports.

Closes #84.

[1] https://docs.python.org/3/whatsnew/3.10.html#distutils-deprecated