### PR TITLE
Add support for PARTITION_LINUX_HOME

### DIFF
--- a/src/_pedmodule.c
+++ b/src/_pedmodule.c
@@ -675,6 +675,10 @@ MOD_INIT(_ped) {
         PyModule_AddIntConstant(m, "PARTITION_BLS_BOOT", PED_PARTITION_BLS_BOOT);
     }
 
+    if (PED_PARTITION_LAST_FLAG > 20) {
+        PyModule_AddIntConstant(m, "PARTITION_LINUX_HOME", PED_PARTITION_LINUX_HOME);
+    }
+
     PyModule_AddIntConstant(m, "DISK_CYLINDER_ALIGNMENT", PED_DISK_CYLINDER_ALIGNMENT);
     PyModule_AddIntConstant(m, "DISK_GPT_PMBR_BOOT", PED_DISK_GPT_PMBR_BOOT);
 

--- a/src/parted/__init__.py
+++ b/src/parted/__init__.py
@@ -206,6 +206,10 @@ if hasattr(_ped, 'PARTITION_BLS_BOOT'):
     # pylint: disable=E0611
     from _ped import PARTITION_BLS_BOOT
     partitions[PARTITION_BLS_BOOT] = "bls_boot"
+if hasattr(_ped, 'PARTITION_LINUX_HOME'):
+    # pylint: disable=E0611
+    from _ped import PARTITION_LINUX_HOME
+    partitions[PARTITION_LINUX_HOME] = "linux-home"
 
 from _ped import DISK_CYLINDER_ALIGNMENT
 from _ped import DISK_GPT_PMBR_BOOT


### PR DESCRIPTION
Used to set the systemd Linux /home directory GUID on a GPT partition.

Note that "linux-home" isn't a typo. Upstream has inconsistent use of _
and - (eg. bls_boot vs. linux-home).