### PR TITLE
Support new PARTITION_TYPE features from parted 3.5 (#91)

### DIFF
--- a/src/_pedmodule.c
+++ b/src/_pedmodule.c
@@ -685,6 +685,11 @@ MOD_INIT(_ped) {
     PyModule_AddIntConstant(m, "DISK_TYPE_EXTENDED", PED_DISK_TYPE_EXTENDED);
     PyModule_AddIntConstant(m, "DISK_TYPE_PARTITION_NAME", PED_DISK_TYPE_PARTITION_NAME);
 
+#if PED_DISK_TYPE_LAST_FEATURE > 2
+    PyModule_AddIntConstant(m, "DISK_TYPE_PARTITION_TYPE_ID", PED_DISK_TYPE_PARTITION_TYPE_ID);
+    PyModule_AddIntConstant(m, "DISK_TYPE_PARTITION_TYPE_UUID", PED_DISK_TYPE_PARTITION_TYPE_UUID);
+#endif
+
     /* add PedFileSystemType as _ped.FileSystemType */
     if (PyType_Ready(&_ped_FileSystemType_Type_obj) < 0)
         return MOD_ERROR_VAL;

--- a/src/parted/__init__.py
+++ b/src/parted/__init__.py
@@ -217,6 +217,14 @@ from _ped import DISK_GPT_PMBR_BOOT
 from _ped import DISK_TYPE_EXTENDED
 from _ped import DISK_TYPE_PARTITION_NAME
 
+if hasattr(_ped, 'DISK_TYPE_PARTITION_TYPE_ID'):
+    # pylint: disable=E0611
+    from _ped import DISK_TYPE_PARTITION_TYPE_ID
+
+if hasattr(_ped, 'DISK_TYPE_PARTITION_TYPE_UUID'):
+    # pylint: disable=E0611
+    from _ped import DISK_TYPE_PARTITION_TYPE_UUID
+
 from _ped import EXCEPTION_TYPE_INFORMATION
 from _ped import EXCEPTION_TYPE_WARNING
 from _ped import EXCEPTION_TYPE_ERROR

--- a/tests/test__ped_disktype.py
+++ b/tests/test__ped_disktype.py
@@ -68,18 +68,30 @@ class DiskTypeCheckFeatureTestCase(RequiresDiskTypes):
             self.assertFalse(self.disktype[name].check_feature(_ped.DISK_TYPE_EXTENDED))
             self.assertTrue(self.disktype[name].check_feature(_ped.DISK_TYPE_PARTITION_NAME))
 
-        # The following types support all features
+        # The following types support both features
         for name in ['dvh']:
             self.assertTrue(self.disktype[name].check_feature(_ped.DISK_TYPE_EXTENDED))
             self.assertTrue(self.disktype[name].check_feature(_ped.DISK_TYPE_PARTITION_NAME))
 
+        # With parted 3.5+, msdos supports PED_DISK_TYPE_PARTITION_TYPE_ID
+        # and gpt supports PED_DISK_TYPE_PARTITION_TYPE_UUID
+        if hasattr(_ped, "DISK_TYPE_PARTITION_TYPE_ID"):
+            self.assertTrue(self.disktype["msdos"].check_feature(_ped.DISK_TYPE_PARTITION_TYPE_ID))
+            self.assertTrue(self.disktype["gpt"].check_feature(_ped.DISK_TYPE_PARTITION_TYPE_UUID))
+
 class DiskTypeStrTestCase(RequiresDiskTypes):
     def runTest(self):
-        self.assertEqual(str(self.disktype['msdos']), '_ped.DiskType instance --\n  name: msdos  features: 1')
+        if hasattr(_ped, "DISK_TYPE_PARTITION_TYPE_ID"):
+            self.assertEqual(str(self.disktype['msdos']), '_ped.DiskType instance --\n  name: msdos  features: 5')
+        else:
+            self.assertEqual(str(self.disktype['msdos']), '_ped.DiskType instance --\n  name: msdos  features: 1')
         self.assertEqual(str(self.disktype['aix']), '_ped.DiskType instance --\n  name: aix  features: 0')
         self.assertEqual(str(self.disktype['sun']), '_ped.DiskType instance --\n  name: sun  features: 0')
         self.assertEqual(str(self.disktype['amiga']), '_ped.DiskType instance --\n  name: amiga  features: 2')
-        self.assertEqual(str(self.disktype['gpt']), '_ped.DiskType instance --\n  name: gpt  features: 2')
+        if hasattr(_ped, "DISK_TYPE_PARTITION_TYPE_UUID"):
+            self.assertEqual(str(self.disktype['gpt']), '_ped.DiskType instance --\n  name: gpt  features: 10')
+        else:
+            self.assertEqual(str(self.disktype['gpt']), '_ped.DiskType instance --\n  name: gpt  features: 2')
         self.assertEqual(str(self.disktype['mac']), '_ped.DiskType instance --\n  name: mac  features: 2')
         self.assertEqual(str(self.disktype['bsd']), '_ped.DiskType instance --\n  name: bsd  features: 0')
         self.assertEqual(str(self.disktype['pc98']), '_ped.DiskType instance --\n  name: pc98  features: 2')


### PR DESCRIPTION
This adds constants for the new PARTITION_TYPE features added
in parted 3.5 (commit 61b3a9733c0e0a79ccc43096642d378c8706add6 )
and adjusts the disk type tests to test for them correctly.

Note this relies on being able to evaluate the
PED_DISK_TYPE_LAST_FEATURE macro at preprocessor time, which is
not the case with current upstream parted. See
https://github.com/dcantrell/pyparted/issues/91#issuecomment-1160788315
for full details on this. The existing attempts to add constants
based on PED_PARTITION_LAST_FLAG in the same manner also do not
work with current upstream parted.

Signed-off-by: Adam Williamson <awilliam@redhat.com>