### PR TITLE
Expose new partition type ID and UUID accessors

### DIFF
--- a/examples/dump_partitions.py
+++ b/examples/dump_partitions.py
@@ -23,10 +23,14 @@ print the partitions in a device/file according to pyparted
 """
 
 import parted
+import sys
 import uuid
 
 # adjust as needed, eg /dev/sdc..
 device="sdcard.img"
+
+if len(sys.argv) == 2:
+    device = sys.argv[1]
 
 # A device is a "thing" with own properties (type, manufacturer etc) - its a
 # high level abstraction that lets you just identify you have the right device

--- a/examples/dump_partitions.py
+++ b/examples/dump_partitions.py
@@ -23,6 +23,7 @@ print the partitions in a device/file according to pyparted
 """
 
 import parted
+import uuid
 
 # adjust as needed, eg /dev/sdc..
 device="sdcard.img"
@@ -70,6 +71,13 @@ for partition in disk.partitions:
     print(f"  busy: {partition.busy}")
     print(f"  path: {partition.path}")
     print(f"  type: {partition.type}")
+    if (hasattr(parted, "DISK_TYPE_PARTITION_TYPE_ID") and
+        disk.supportsFeature(parted.DISK_TYPE_PARTITION_TYPE_ID)):
+        print(f"  type id: {partition.type_id}")
+    if (hasattr(parted, "DISK_TYPE_PARTITION_TYPE_UUID") and
+        disk.supportsFeature(parted.DISK_TYPE_PARTITION_TYPE_UUID)):
+        uuid_str = str(uuid.UUID(bytes=partition.type_uuid))
+        print(f"  type uuid: {uuid_str}")
     print(f"  size(MB): {partition.getSize()}")
 
     # supported only by GPT partition tables

--- a/examples/gpt_type_uuid.py
+++ b/examples/gpt_type_uuid.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+#
+# This example script is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version so long as this copyright notice remains intact.
+#
+# This example script is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this example script.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+print and change the GPT partition type UUID
+"""
+
+import parted
+import sys
+import uuid
+
+# adjust as needed, eg /dev/sdc..
+device="sdcard.img"
+
+if len(sys.argv) not in (3, 4):
+    print(f"{sys.argv[0]}: DEVICE PART-NUM [NEW-UUID]")
+    sys.exit(1)
+
+devpath = sys.argv[1]
+partnum = int(sys.argv[2])
+newuuid = None
+if len(sys.argv) == 4:
+    newuuid = uuid.UUID(sys.argv[3])
+
+device = parted.getDevice(devpath)
+disk = parted.newDisk(device)
+
+if partnum == 0 or partnum > len(disk.partitions):
+    print(f"{sys.argv[0]}: partition {partnum} must be in range 1:{len(disk.partitions)}")
+    sys.exit(1)
+
+part = disk.partitions[partnum-1]
+
+if not hasattr(parted, "DISK_TYPE_PARTITION_TYPE_UUID"):
+    print(f"{sys.argv[0]}: build against parted version >= 3.5 is required")
+    sys.exit(1)
+
+if not disk.supportsFeature(parted.DISK_TYPE_PARTITION_TYPE_UUID):
+    print(f"{sys.argv[0]}: disk label {disk.type} does not support partition type UUIDs")
+    sys.exit(1)
+
+if newuuid is not None:
+    part.type_uuid = newuuid.bytes
+    disk.commit()
+
+print(str(uuid.UUID(bytes=part.type_uuid)))

--- a/include/docstrings/pydisk.h
+++ b/include/docstrings/pydisk.h
@@ -27,6 +27,8 @@
 
 #include <Python.h>
 
+#include <parted/parted.h>
+
 PyDoc_STRVAR(partition_destroy_doc,
 "destroy(self) -> None\n\n"
 "Destroys the Partition object.");
@@ -69,6 +71,36 @@ PyDoc_STRVAR(partition_get_name_doc,
 "On disk labels that support it, this method returns the partition's name.  On\n"
 "all other disk labels, _ped.PartitionException will be raised.  Before calling\n"
 "this method, DiskType.check_feature() can be called to check for support.");
+
+#if PED_DISK_TYPE_LAST_FEATURE > 2
+PyDoc_STRVAR(partition_set_type_id_doc,
+"set_type_id(self, string) -> boolean\n\n"
+"On disk labels that support it, this method sets the partition's type id.\n"
+"Before attempting this operation, DiskType.check_feature() can be used to\n"
+"determine if it is even supported.  On error, _ped.PartitionException will\n"
+"be raised.");
+
+PyDoc_STRVAR(partition_get_type_id_doc,
+"get_type_id(self) -> string\n\n"
+"On disk labels that support it, this method returns the partition's type id.  On\n"
+"all other disk labels, _ped.PartitionException will be raised.  Before calling\n"
+"this method, DiskType.check_feature() can be called to check for support.");
+#endif /* PED_DISK_TYPE_LAST_FEATURE > 2 */
+
+#if PED_DISK_TYPE_LAST_FEATURE > 4
+PyDoc_STRVAR(partition_set_type_uuid_doc,
+"set_type_uuid(self, string) -> boolean\n\n"
+"On disk labels that support it, this method sets the partition's type uuid.\n"
+"Before attempting this operation, DiskType.check_feature() can be used to\n"
+"determine if it is even supported.  On error, _ped.PartitionException will\n"
+"be raised.");
+
+PyDoc_STRVAR(partition_get_type_uuid_doc,
+"get_type_uuid(self) -> string\n\n"
+"On disk labels that support it, this method returns the partition's type uuid.  On\n"
+"all other disk labels, _ped.PartitionException will be raised.  Before calling\n"
+"this method, DiskType.check_feature() can be called to check for support.");
+#endif /* PED_DISK_TYPE_LAST_FEATURE > 4 */
 
 PyDoc_STRVAR(partition_is_busy_doc,
 "is_busy(self) -> boolean\n\n"

--- a/include/pydisk.h
+++ b/include/pydisk.h
@@ -133,6 +133,14 @@ PyObject *py_ped_partition_is_flag_available(_ped_Partition *, PyObject *);
 PyObject *py_ped_partition_set_system(_ped_Partition *, PyObject *);
 PyObject *py_ped_partition_set_name(_ped_Partition *, PyObject *);
 PyObject *py_ped_partition_get_name(_ped_Partition *, PyObject *);
+#if PED_DISK_TYPE_LAST_FEATURE > 2
+PyObject *py_ped_partition_set_type_id(_ped_Partition *, PyObject *);
+PyObject *py_ped_partition_get_type_id(_ped_Partition *, PyObject *);
+#endif /* PED_DISK_TYPE_LAST_FEATURE > 2 */
+#if PED_DISK_TYPE_LAST_FEATURE > 4
+PyObject *py_ped_partition_set_type_uuid(_ped_Partition *, PyObject *);
+PyObject *py_ped_partition_get_type_uuid(_ped_Partition *, PyObject *);
+#endif /* PED_DISK_TYPE_LAST_FEATURE > 4 */
 PyObject *py_ped_partition_is_busy(_ped_Partition *, PyObject *);
 PyObject *py_ped_partition_get_path(_ped_Partition *, PyObject *);
 PyObject *py_ped_partition_reset_num(_ped_Partition *, PyObject *);

--- a/include/typeobjects/pydisk.h
+++ b/include/typeobjects/pydisk.h
@@ -29,6 +29,8 @@
 #include <Python.h>
 #include <structmember.h>
 
+#include <parted/parted.h>
+
 /* _ped.Partition type object */
 static PyMemberDef _ped_Partition_members[] = {
     {"disk", T_OBJECT, offsetof(_ped_Partition, disk), READONLY,
@@ -57,6 +59,18 @@ static PyMethodDef _ped_Partition_methods[] = {
                  partition_set_name_doc},
     {"get_name", (PyCFunction) py_ped_partition_get_name, METH_VARARGS,
                  partition_get_name_doc},
+#if PED_DISK_TYPE_LAST_FEATURE > 2
+    {"set_type_id", (PyCFunction) py_ped_partition_set_type_id, METH_VARARGS,
+                 partition_set_type_id_doc},
+    {"get_type_id", (PyCFunction) py_ped_partition_get_type_id, METH_VARARGS,
+                 partition_get_type_id_doc},
+#endif /* PED_DISK_TYPE_LAST_FEATURE > 2 */
+#if PED_DISK_TYPE_LAST_FEATURE > 4
+    {"set_type_uuid", (PyCFunction) py_ped_partition_set_type_uuid, METH_VARARGS,
+                 partition_set_type_uuid_doc},
+    {"get_type_uuid", (PyCFunction) py_ped_partition_get_type_uuid, METH_VARARGS,
+                 partition_get_type_uuid_doc},
+#endif /* PED_DISK_TYPE_LAST_FEATURE > 4 */
     {"is_busy", (PyCFunction) py_ped_partition_is_busy, METH_VARARGS,
                 partition_is_busy_doc},
     {"get_path", (PyCFunction) py_ped_partition_get_path, METH_VARARGS,

--- a/src/parted/partition.py
+++ b/src/parted/partition.py
@@ -137,11 +137,51 @@ class Partition(object):
         except parted.PartitionException:
             return None
 
+    def set_type_id(self, id):
+        """Set the partition type id, as an integer, on supported labels.
+           Requires the DISK_TYPE_PARTITION_TYPE_ID flag to be available."""
+        if not hasattr(self.getPedPartition(), "set_type_id"):
+            raise NotImplementedError("Requires build against parted > 3.5")
+
+        self.getPedPartition().set_type_id(id)
+
+    def get_type_id(self):
+        """The partition type uuid, as an integer, on supported labels.
+           Requires the DISK_TYPE_PARTITION_TYPE_ID flag to be available."""
+        if not hasattr(self.getPedPartition(), "get_type_id"):
+            raise NotImplementedError("Requires build against parted > 3.5")
+
+        try:
+            return self.__partition.get_type_id()
+        except parted.PartitionException:
+            return None
+
+    def set_type_uuid(self, uuid):
+        """Set the partition type uuid, as 16 bytes, on supported labels.
+           Requires the DISK_TYPE_PARTITION_TYPE_UUID flag to be available."""
+        if not hasattr(self.getPedPartition(), "set_type_uuid"):
+            raise NotImplementedError("Requires build against parted > 3.5")
+
+        self.getPedPartition().set_type_uuid(uuid)
+
+    def get_type_uuid(self):
+        """The partition type uuid, as 16 bytes, on supported labels.
+           Requires the DISK_TYPE_PARTITION_TYPE_UUID flag to be available."""
+        if not hasattr(self.getPedPartition(), "get_type_uuid"):
+            raise NotImplementedError("Requires build against parted > 3.5")
+
+        try:
+            return self.__partition.get_type_uuid()
+        except parted.PartitionException:
+            return None
+
     fileSystem = property(lambda s: s._fileSystem, lambda s, v: setattr(s, "_fileSystem", v))
     geometry = property(lambda s: s._geometry, lambda s, v: setattr(s, "_geometry", v))
     system = property(lambda s: s.__writeOnly("system"), lambda s, v: s.__partition.set_system(v))
     type = property(lambda s: s.__partition.type, lambda s, v: setattr(s.__partition, "type", v))
     name = property(get_name, set_name)
+    type_uuid = property(get_type_uuid, set_type_uuid)
+    type_id = property(get_type_id, set_type_id)
 
     @localeC
     def getFlag(self, flag):

--- a/src/pydisk.c
+++ b/src/pydisk.c
@@ -1325,6 +1325,166 @@ PyObject *py_ped_partition_get_name(_ped_Partition *s, PyObject *args) {
     return PyUnicode_FromString(ret);
 }
 
+#if PED_DISK_TYPE_LAST_FEATURE > 2
+PyObject *py_ped_partition_set_type_id(_ped_Partition *s, PyObject *args) {
+    PedPartition *part = NULL;
+    int id;
+    int ret = 0;
+
+    if (!PyArg_ParseTuple(args, "i", &id)) {
+        return (PyObject *) NULL;
+    }
+
+    part = _ped_Partition2PedPartition(s);
+
+    if (part == NULL) {
+        return (PyObject *) NULL;
+    }
+
+    /* ped_partition_set_type_id will assert on this. */
+    if (!ped_partition_is_active(part)) {
+        PyErr_Format(PartitionException, "Could not set system flag on inactive partition %s%d", part->disk->dev->path, part->num);
+        return (PyObject *) NULL;
+    }
+
+    ret = ped_partition_set_type_id(part, (uint8_t)id);
+
+    if (ret == 0) {
+        if (partedExnRaised) {
+            partedExnRaised = 0;
+
+            if (!PyErr_ExceptionMatches(PartedException) && !PyErr_ExceptionMatches(PyExc_NotImplementedError)) {
+                PyErr_SetString(PartitionException, partedExnMessage);
+            }
+        } else {
+            PyErr_Format(PartitionException, "Could not set id on partition %s%d", part->disk->dev->path, part->num);
+        }
+
+        return (PyObject *) NULL;
+    }
+
+    if (ret) {
+        Py_RETURN_TRUE;
+    } else {
+        Py_RETURN_FALSE;
+    }
+}
+
+PyObject *py_ped_partition_get_type_id(_ped_Partition *s, PyObject *args) {
+    PedPartition *part = NULL;
+    uint8_t ret;
+
+    part = _ped_Partition2PedPartition(s);
+
+    if (part == NULL) {
+        return (PyObject *) NULL;
+    }
+
+    /* ped_partition_get_type_id will assert on this. */
+    if (!ped_partition_is_active(part)) {
+        PyErr_Format(PartitionException, "Could not get id on inactive partition %s%d", part->disk->dev->path, part->num);
+        return (PyObject *) NULL;
+    }
+
+    ret = ped_partition_get_type_id(part);
+
+    return PyLong_FromLong((long)ret);
+}
+#endif /* PED_DISK_TYPE_LAST_FEATURE > 2 */
+
+#if PED_DISK_TYPE_LAST_FEATURE > 4
+PyObject *py_ped_partition_set_type_uuid(_ped_Partition *s, PyObject *args) {
+    PedPartition *part = NULL;
+    PyObject *in_uuid_obj = NULL;
+    char *in_uuid;
+    Py_ssize_t in_uuid_len;
+    int ret = 0;
+
+    if (!PyArg_ParseTuple(args, "O", &in_uuid_obj)) {
+        return (PyObject *) NULL;
+    }
+
+    part = _ped_Partition2PedPartition(s);
+
+    if (part == NULL) {
+        return (PyObject *) NULL;
+    }
+
+    /* ped_partition_set_type_uuid will assert on this. */
+    if (!ped_partition_is_active(part)) {
+        PyErr_Format(PartitionException, "Could not set system flag on inactive partition %s%d", part->disk->dev->path, part->num);
+        return (PyObject *) NULL;
+    }
+
+    PyBytes_AsStringAndSize(in_uuid_obj, &in_uuid, &in_uuid_len);
+
+    if (in_uuid_len != 16) {
+        PyErr_Format(PartitionException, "UUID should be 16 byte array not %d", in_uuid_len);
+        return (PyObject *) NULL;
+    }
+
+    ret = ped_partition_set_type_uuid(part, (uint8_t *)in_uuid);
+
+    if (ret == 0) {
+        if (partedExnRaised) {
+            partedExnRaised = 0;
+
+            if (!PyErr_ExceptionMatches(PartedException) && !PyErr_ExceptionMatches(PyExc_NotImplementedError)) {
+                PyErr_SetString(PartitionException, partedExnMessage);
+            }
+        } else {
+            PyErr_Format(PartitionException, "Could not set uuid on partition %s%d", part->disk->dev->path, part->num);
+        }
+
+        return (PyObject *) NULL;
+    }
+
+    if (ret) {
+        Py_RETURN_TRUE;
+    } else {
+        Py_RETURN_FALSE;
+    }
+}
+
+PyObject *py_ped_partition_get_type_uuid(_ped_Partition *s, PyObject *args) {
+    PedPartition *part = NULL;
+    char *ret = NULL;
+    PyObject *pyret;
+
+    part = _ped_Partition2PedPartition(s);
+
+    if (part == NULL) {
+        return (PyObject *) NULL;
+    }
+
+    /* ped_partition_get_type_uuid will assert on this. */
+    if (!ped_partition_is_active(part)) {
+        PyErr_Format(PartitionException, "Could not get uuid on inactive partition %s%d", part->disk->dev->path, part->num);
+        return (PyObject *) NULL;
+    }
+
+    ret = (char *) ped_partition_get_type_uuid(part);
+
+    if (ret == NULL) {
+        if (partedExnRaised) {
+            partedExnRaised = 0;
+
+            if (!PyErr_ExceptionMatches(PartedException) && !PyErr_ExceptionMatches(PyExc_NotImplementedError)) {
+                PyErr_SetString(PartitionException, partedExnMessage);
+            }
+        } else {
+            PyErr_Format(PartitionException, "Could not read uuid on partition %s%d", part->disk->dev->path, part->num);
+        }
+
+        return (PyObject *) NULL;
+    }
+
+    pyret = PyBytes_FromStringAndSize(ret, 16);
+    free(ret);
+    return pyret;
+}
+#endif /* PED_DISK_TYPE_LAST_FEATURE > 4 */
+
 PyObject *py_ped_partition_is_busy(_ped_Partition *s, PyObject *args) {
     PedPartition *part = NULL;
     int ret = 0;

--- a/tests/baseclass.py
+++ b/tests/baseclass.py
@@ -180,6 +180,13 @@ class RequiresPartition(RequiresDisk):
                                     start=1, end=100, fs_type=_ped.file_system_type_get("ext2"))
 
 
+# Base class for any test case that requires a _ped.Partition on GPT disk.
+class RequiresGPTPartition(RequiresGPTDisk):
+    def setUp(self):
+        RequiresGPTDisk.setUp(self)
+        self._part = _ped.Partition(disk=self._disk, type=_ped.PARTITION_NORMAL,
+                                    start=0, end=100, fs_type=_ped.file_system_type_get("ext2"))
+
 # Base class for any test case that requires a hash table of all
 # _ped.DiskType objects available
 class RequiresDiskTypes(unittest.TestCase):

--- a/tests/baseclass.py
+++ b/tests/baseclass.py
@@ -177,7 +177,8 @@ class RequiresPartition(RequiresDisk):
     def setUp(self):
         RequiresDisk.setUp(self)
         self._part = _ped.Partition(disk=self._disk, type=_ped.PARTITION_NORMAL,
-                                    start=0, end=100, fs_type=_ped.file_system_type_get("ext2"))
+                                    start=1, end=100, fs_type=_ped.file_system_type_get("ext2"))
+
 
 # Base class for any test case that requires a hash table of all
 # _ped.DiskType objects available

--- a/tests/baseclass.py
+++ b/tests/baseclass.py
@@ -146,11 +146,19 @@ class RequiresDisk(RequiresDevice):
         self._disk = _ped.disk_new_fresh(self._device, _ped.disk_type_get("msdos"))
         self.disk = parted.Disk(PedDisk=self._disk)
 
+    def reopen(self):
+        self._disk = _ped.disk_new(self._device)
+        self.disk = parted.Disk(PedDisk=self._disk)
+
 # Base class for any test case that requires a GPT-labeled _ped.Disk or parted.Disk.
 class RequiresGPTDisk(RequiresDevice):
     def setUp(self):
         RequiresDevice.setUp(self)
         self._disk = _ped.disk_new_fresh(self._device, _ped.disk_type_get("gpt"))
+        self.disk = parted.Disk(PedDisk=self._disk)
+
+    def reopen(self):
+        self._disk = _ped.disk_new(self._device)
         self.disk = parted.Disk(PedDisk=self._disk)
 
 # Base class for any test case that requires a filesystem made and mounted.
@@ -179,6 +187,9 @@ class RequiresPartition(RequiresDisk):
         self._part = _ped.Partition(disk=self._disk, type=_ped.PARTITION_NORMAL,
                                     start=1, end=100, fs_type=_ped.file_system_type_get("ext2"))
 
+    def reopen(self):
+        RequiresDisk.reopen(self)
+        self._part = self._disk.next_partition(self._disk.next_partition())
 
 # Base class for any test case that requires a _ped.Partition on GPT disk.
 class RequiresGPTPartition(RequiresGPTDisk):
@@ -186,6 +197,10 @@ class RequiresGPTPartition(RequiresGPTDisk):
         RequiresGPTDisk.setUp(self)
         self._part = _ped.Partition(disk=self._disk, type=_ped.PARTITION_NORMAL,
                                     start=0, end=100, fs_type=_ped.file_system_type_get("ext2"))
+
+    def reopen(self):
+        RequiresDisk.reopen(self)
+        self._part = self._disk.next_partition()
 
 # Base class for any test case that requires a hash table of all
 # _ped.DiskType objects available


### PR DESCRIPTION
The parted 3.5 release introduced new APIs for getting/setting the partition type ID and UUID metadata. This in turn needs to be exposed in pyparted.

This unlocks ability for tools like blivet to then support the systemd discoverable partition spec by setting suitable GPT UUIDs on partitions.

I wasn't clear on what policy pyparted takes wrt back-compatibility with older parted releases. Since commit 07ba882d04fa2099b53d41370416b97957d2abcb  conditionally exposed the new enum constants, I tried to follow its lead and conditionally expose the new APIs too. 
