### PR TITLE
tests: Remove DeviceFreeAllTestCase

### DIFF
--- a/tests/test__ped_ped.py
+++ b/tests/test__ped_ped.py
@@ -232,11 +232,6 @@ class DeviceProbeAllTestCase(RequiresDevice, BuildList):
         self.assertGreater(
             len([e for e in lst if e.path.startswith(prefix)]), 0)
 
-class DeviceFreeAllTestCase(RequiresDevice):
-    def runTest(self):
-        _ped.device_probe_all()
-        self.assertEqual(_ped.device_free_all(), None)
-
 class DiskTypeGetTestCase(unittest.TestCase):
     def runTest(self):
         for d in ["aix", "amiga", "bsd", "dvh", "gpt", "loop", "mac", "msdos",


### PR DESCRIPTION
This test calls _ped.device_free_all(), which destroys all the devices in libparted's devices list, and it frees the memory allocated for the device.

But there may still be objects pointing to that memory, and when they are garbage collected pyparted can crash with a Floating Point Error if it hits a divide by 0.

This should usually never be called, but if it is it must only be called after all the users of the device have been freed first. In python there is no way to guarantee that.