### PR TITLE
tests: Relax unnecessarily-strict constraint

### DIFF
--- a/tests/test__ped_partition.py
+++ b/tests/test__ped_partition.py
@@ -239,7 +239,7 @@ class PartitionMSDOSTypeIDTestCase(RequiresPartition):
 
         # Persist the changes
         self._disk.add_partition(
-            self._part, self._device.get_optimal_aligned_constraint()
+            self._part, self._device.get_minimal_aligned_constraint()
         )
         self._disk.commit_to_dev()
 


### PR DESCRIPTION
Debian's parted package carries a [patch](https://salsa.debian.org/parted-team/parted/-/blob/master/debian/patches/align-new-partitions-on-fresh-disks.patch) to apply alignment constraints to new partitions created on fresh disks.  This caused `tests.test__ped_partition.PartitionMSDOSTypeIDTestCase.runTest` to fail as follows:

  _ped.PartitionException: Unable to satisfy all constraints on the partition.

While I realize that a Debian patch isn't strictly upstream's problem, in this case the optimal alignment constraint doesn't seem to have anything to do with what's actually being tested, so relax it to a minimal alignment constraint.