### PR TITLE
Handle non-UTF-8 device models

### DIFF
--- a/src/pydevice.c
+++ b/src/pydevice.c
@@ -256,7 +256,15 @@ PyObject *_ped_Device_get(_ped_Device *self, void *closure)
 
     if (!strcmp(member, "model")) {
         if (self->model != NULL) {
-            return PyUnicode_FromString(self->model);
+            // There's at least one case of a non-UTF-8 model in the wild where
+            // using PyUnicode_FromString would crash (model b"MMC H8G4a\x92"
+            // on Wyse 3040 thin clients).
+            //
+            // Using PyUnicode_FromFormat instead will convert the 0x92 byte to
+            // the replacement character.
+            //
+            // https://github.com/dcantrell/pyparted/issues/76
+            return PyUnicode_FromFormat("%s", self->model)
         } else {
             return PyUnicode_FromString("");
         }


### PR DESCRIPTION
Took me a while to figure out why Fedora 40 installer was dying on me on a Wyse 3040 thin client and I finally narrowed it down to pyparted and found the associated issue (linked).

The fix proposed in the issue comments worked for me so I figured I'd send a PR.

Before:

    >>> import parted
    >>> parted.getDevice('/dev/mmcblk0').model
    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
      File "/root/pyparted/build/lib.linux-x86_64-cpython-312/parted/device.py", line 69, in model
        return self.__device.model
               ^^^^^^^^^^^^^^^^^^^
    UnicodeDecodeError: 'utf-8' codec can't decode byte 0x92 in position 9: invalid start byte

After:

    >>> import parted
    >>> parted.getDevice('/dev/mmcblk0').model
    'MMC H8G4a�'

Resolves: https://github.com/dcantrell/pyparted/issues/76